### PR TITLE
Avoid to crash when DNS reverse lookup is done.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macOS-12
         swift-compat-ver:
           - '5'
@@ -40,7 +40,7 @@ jobs:
           build-${{ github.workspace }}-
     - uses: YOCKOW/Action-setup-swift@main
       with:
-        swift-version: '5.6'
+        swift-version: '5.7.2'
     # DEBUG mode
     - name: Test with debug mode.
       id: debug_test

--- a/Sources/NetworkGear/Domain+IPAddress+DNSLookup.swift
+++ b/Sources/NetworkGear/Domain+IPAddress+DNSLookup.swift
@@ -65,11 +65,10 @@ extension IPAddress {
     func __getNameInfo<T>(_ sockAddr: T) -> CInt where T: CIPSocketAddress {
       let size = CSocketRelatedSize(sockAddr.size)
       return withUnsafePointer(to: sockAddr) {
-        return $0.withMemoryRebound(to: CSocketAddress.self, capacity: 2) {
-          return getnameinfo($0, size,
-                             domain_p, CSocketRelatedSize(NI_MAXHOST),
-                             nil, 0, NI_NAMEREQD)
-        }
+        let asSockAddr = UnsafeRawPointer($0).bindMemory(to: CSocketAddress.self, capacity: 2)
+        return getnameinfo(asSockAddr, size,
+                           domain_p, CSocketRelatedSize(NI_MAXHOST),
+                           nil, 0, NI_NAMEREQD)
       }
     }
     

--- a/Tests/NetworkGearTests/IPAddressTests.swift
+++ b/Tests/NetworkGearTests/IPAddressTests.swift
@@ -57,4 +57,9 @@ final class IPAddressTests: XCTestCase {
     
     XCTAssertEqual(v4!, v4Mapped!)
   }
+
+  func test_DNSReverseLookup() throws {
+    let ipAddress = try XCTUnwrap(IPAddress(string: "2001:e42:102:1820:160:16:237:39"))
+    XCTAssertEqual(ipAddress.domain, Domain("Choeropsis-liberiensis.YOCKOW.jp"))
+  }
 }


### PR DESCRIPTION
Swift seems to have changed its implementation related to `UnsafePointer`s: https://github.com/apple/swift/commit/9ead7d039d3c24a25efc96a959c069e2027bd724 https://github.com/apple/swift/commit/c2dfb94f88180ce490a18a0c2652a2f51d0fceef https://github.com/apple/swift/commit/b520063e5380d7919f12cac551c7d162464983fb https://github.com/apple/swift/commit/92087a8f620ebb5bac6741012aef2ef82c3b6b33